### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Both source code are in the `gh-pages` branch.
 * [Bower](http://bower.io/): `bower install --save viewability`
 * [npm](https://www.npmjs.org/): `npm install --save viewability`
 * Direct download the latest version: https://github.com/kahwee/viewability/releases
-* [jsDelivr CDN](http://www.jsdelivr.com/#!viewability): `<script src="//cdn.jsdelivr.net/viewability/VERSION/viewability.min.js"></script>`
+* [jsDelivr CDN](http://www.jsdelivr.com/#!viewability): `<script src="https://cdn.jsdelivr.net/npm/viewability@VERSION/dist/viewability.min.js"></script>`
 
 # Usage
 
@@ -42,7 +42,7 @@ Both source code are in the `gh-pages` branch.
 Loading it directly to the browser with `viewability` exposed to the window:
 
 ```html
-<script src="//cdn.jsdelivr.net/viewability/latest/viewability.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/viewability@latest/dist/viewability.min.js"></script>
 <script>
   var v = viewability.vertical(document.getElementById('red-box'));
   console.log(v);


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/viewability.

Feel free to ping me if you have any questions regarding this change.